### PR TITLE
Add search disable flag

### DIFF
--- a/submodules/ContactListUI/Sources/ContactListNode.swift
+++ b/submodules/ContactListUI/Sources/ContactListNode.swift
@@ -130,9 +130,16 @@ private enum ContactListNodeEntry: Comparable, Identifiable {
     func item(context: AccountContext, presentationData: PresentationData, interaction: ContactListNodeInteraction, isSearch: Bool) -> ListViewItem {
         switch self {
             case let .search(theme, strings):
-                return ChatListSearchItem(theme: theme, placeholder: strings.Contacts_SearchLabel, activate: {
-                    interaction.activateSearch()
-                })
+                return ChatListSearchItem(
+                    theme: theme,
+                    isEnabled: !AppConfiguration.disableSearch,
+                    placeholder: strings.Contacts_SearchLabel,
+                    activate: {
+                        if !AppConfiguration.disableSearch {
+                            interaction.activateSearch()
+                        }
+                    }
+                )
             case let .sort(_, strings, sortOrder):
                 var text = strings.Contacts_SortedByName
                 if case .presence = sortOrder {

--- a/submodules/SettingsUI/Sources/Notifications/Exceptions/NotificationExceptionControllerNode.swift
+++ b/submodules/SettingsUI/Sources/Notifications/Exceptions/NotificationExceptionControllerNode.swift
@@ -312,9 +312,16 @@ private enum NotificationExceptionEntry : ItemListNodeEntry {
         let arguments = arguments as! NotificationExceptionArguments
         switch self {
             case let .search(theme, strings):
-                return NotificationSearchItem(theme: theme, placeholder: strings.Common_Search, activate: {
-                    arguments.activateSearch()
-                })
+                return NotificationSearchItem(
+                    theme: theme,
+                    isEnabled: !AppConfiguration.disableSearch,
+                    placeholder: strings.Common_Search,
+                    activate: {
+                        if !AppConfiguration.disableSearch {
+                            arguments.activateSearch()
+                        }
+                    }
+                )
             case let .addException(theme, strings, mode, editing):
                 let icon: UIImage?
                 switch mode {

--- a/submodules/TelegramCore/Sources/State/ManagedAppConfigurationUpdates.swift
+++ b/submodules/TelegramCore/Sources/State/ManagedAppConfigurationUpdates.swift
@@ -31,6 +31,7 @@ func updateAppConfigurationOnce(postbox: Postbox, network: Network) -> Signal<Vo
                         var configuration = configuration
                         configuration.data = data
                         configuration.hash = result.hash
+                        AppConfiguration.disableSearch = data["ios_disable_search"] as? Bool ?? false
                         return configuration
                     })
                     

--- a/submodules/TelegramCore/Sources/SyncCore/SyncCore_AppConfiguration.swift
+++ b/submodules/TelegramCore/Sources/SyncCore/SyncCore_AppConfiguration.swift
@@ -4,6 +4,7 @@ import Postbox
 public struct AppConfiguration: Codable, Equatable {
     public var data: JSON?
     public var hash: Int32
+    public static var disableSearch: Bool = false
     
     public static var defaultValue: AppConfiguration {
         return AppConfiguration(data: nil, hash: 0)

--- a/submodules/TelegramUI/Sources/ChatHistoryListNode.swift
+++ b/submodules/TelegramUI/Sources/ChatHistoryListNode.swift
@@ -265,9 +265,16 @@ private func mappedInsertEntries(context: AccountContext, chatLocation: ChatLoca
                 }
                 return ListViewInsertItem(index: entry.index, previousIndex: entry.previousIndex, item: item, directionHint: entry.directionHint)
             case let .SearchEntry(theme, strings):
-                return ListViewInsertItem(index: entry.index, previousIndex: entry.previousIndex, item: ChatListSearchItem(theme: theme, placeholder: strings.Common_Search, activate: {
-                    controllerInteraction.openSearch()
-                }), directionHint: entry.directionHint)
+                return ListViewInsertItem(index: entry.index, previousIndex: entry.previousIndex, item: ChatListSearchItem(
+                    theme: theme,
+                    isEnabled: !AppConfiguration.disableSearch,
+                    placeholder: strings.Common_Search,
+                    activate: {
+                        if !AppConfiguration.disableSearch {
+                            controllerInteraction.openSearch()
+                        }
+                    }
+                ), directionHint: entry.directionHint)
         }
     }
 }
@@ -322,9 +329,16 @@ private func mappedUpdateEntries(context: AccountContext, chatLocation: ChatLoca
                 }
                 return ListViewUpdateItem(index: entry.index, previousIndex: entry.previousIndex, item: item, directionHint: entry.directionHint)
             case let .SearchEntry(theme, strings):
-                return ListViewUpdateItem(index: entry.index, previousIndex: entry.previousIndex, item: ChatListSearchItem(theme: theme, placeholder: strings.Common_Search, activate: {
-                    controllerInteraction.openSearch()
-                }), directionHint: entry.directionHint)
+                return ListViewUpdateItem(index: entry.index, previousIndex: entry.previousIndex, item: ChatListSearchItem(
+                    theme: theme,
+                    isEnabled: !AppConfiguration.disableSearch,
+                    placeholder: strings.Common_Search,
+                    activate: {
+                        if !AppConfiguration.disableSearch {
+                            controllerInteraction.openSearch()
+                        }
+                    }
+                ), directionHint: entry.directionHint)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add global `AppConfiguration.disableSearch` flag
- toggle search bars in chat history, contacts, and notifications based on the flag
- block search activation when disabled

## Testing
- `git commit -m "Add global search disable flag"`

------
https://chatgpt.com/codex/tasks/task_e_6875586cb3fc832a8b16e0956bfab0f6